### PR TITLE
Added `children` to `LinkProps`.

### DIFF
--- a/src/react/router/Link.hx
+++ b/src/react/router/Link.hx
@@ -21,6 +21,8 @@ typedef LinkProps = {
 		Allows access to the underlying ref of the component.
 	*/
 	@:optional var innerRef:HtmlElement->Void;
+
+	@:optional var children:ReactFragment;
 }
 
 /**


### PR DESCRIPTION
It's needed to use the component with Coconut.